### PR TITLE
Missing mandatory options

### DIFF
--- a/nixops_vault/nix/default.nix
+++ b/nixops_vault/nix/default.nix
@@ -1,6 +1,6 @@
 {
- # config_exporters = { optionalAttrs, ... }: [];
- # options = [];
+  config_exporters = { optionalAttrs, ... }: [];
+  options = [];
   resources = { evalResources, zipAttrs, resourcesByType, ... }: {
     vaultApprole = evalResources ./vault-approle.nix (zipAttrs resourcesByType.vaultApprole or []);
     vaultPolicy = evalResources ./vault-policy.nix (zipAttrs resourcesByType.vaultPolicy or []);


### PR DESCRIPTION
When building nixops with multiple plugins, the eval fails without the 2 added options

```
error: attribute 'options' missing, at /home/.cache/pypoetry/virtualenvs/nixops-test-LVVXKT3N-py3.8/lib/python3.8/site-packages/nix/eval-machine-info.nix:66:54
(use '--show-trace' to show detailed location information)
warning: evaluation of the deployment specification failed; status info may be incorrect
```